### PR TITLE
Changed double quotes to single quotes in the lang file

### DIFF
--- a/lang/en/block_echo360_echocenter.php
+++ b/lang/en/block_echo360_echocenter.php
@@ -24,17 +24,17 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later 
  */
 
-    $string['echocenter'] = "Echo360 EchoCenter";
-    $string['echocenter_link'] = "Launch EchoCenter...";
-    $string['loading'] = "Loading. Please wait...";
+    $string['echocenter'] = 'Echo360 EchoCenter';
+    $string['echocenter_link'] = 'Launch EchoCenter...';
+    $string['loading'] = 'Loading. Please wait...';
 
-    $string['pluginname'] = "Echo360 EchoCenter";
-    $string['openinnewwindow'] = "Open in new window...";
-    $string['not_configured'] = "This block requires system level configuration before it can be used.";
-    $string['configure_link_text'] = "Click here to set the system level configuration for this block.";
-    $string['error_generating_url'] = "An error occurred while generating the URL to the resource. Please contact your system administrator. <br/> {$a}";
-    $string['no_view_capability'] = "You do not have permission to view this content.";
-    $string['not_found_response'] = "The EchoSystem could not find a matching course. Contact your system administrator to verify that lecture capture has been enabled for this course. <br/> {$a}";
-    $string['forbidden_response'] = "The EchoSystem is denying access to this system. Contact your system administrator to verify that this Moodle plugin has been configured correctly. <br/> {$a->classname}";
-    $string['unexpected_response'] = "The EchoSystem returned an unexpected response. Contact your system administrator to verify that this Moodle plugin has been configured correctly. <br/> {$a}";
+    $string['pluginname'] = 'Echo360 EchoCenter';
+    $string['openinnewwindow'] = 'Open in new window...';
+    $string['not_configured'] = 'This block requires system level configuration before it can be used.';
+    $string['configure_link_text'] = 'Click here to set the system level configuration for this block.';
+    $string['error_generating_url'] = 'An error occurred while generating the URL to the resource. Please contact your system administrator. <br/> {$a}';
+    $string['no_view_capability'] = 'You do not have permission to view this content.';
+    $string['not_found_response'] = 'The EchoSystem could not find a matching course. Contact your system administrator to verify that lecture capture has been enabled for this course. <br/> {$a}';
+    $string['forbidden_response'] = 'The EchoSystem is denying access to this system. Contact your system administrator to verify that this Moodle plugin has been configured correctly. <br/> {$a}';
+    $string['unexpected_response'] = 'The EchoSystem returned an unexpected response. Contact your system administrator to verify that this Moodle plugin has been configured correctly. <br/> {$a}';
 ?>


### PR DESCRIPTION
This fixes failing unit test: core_plugin_manager_testcase::test_plugin_states
